### PR TITLE
optional scope parameter

### DIFF
--- a/src/main/actionscript/com/adobe/protocols/oauth2/OAuth2.as
+++ b/src/main/actionscript/com/adobe/protocols/oauth2/OAuth2.as
@@ -140,7 +140,13 @@ package com.adobe.protocols.oauth2
 			urlVariables.client_id = clientId;
 			urlVariables.client_secret = clientSecret;
 			urlVariables.refresh_token = refreshToken;
-			urlVariables.scope = scope;
+			
+			// define optional scope parameter only when scope not null
+			if(scope !== null)
+			{
+				urlVariables.scope = scope;
+			}
+			
 			urlRequest.data = urlVariables;
 			
 			// attach event listeners
@@ -460,7 +466,13 @@ package com.adobe.protocols.oauth2
 			urlVariables.client_secret = resourceOwnerCredentialsGrant.clientSecret;
 			urlVariables.username = resourceOwnerCredentialsGrant.username;
 			urlVariables.password = resourceOwnerCredentialsGrant.password;
-			urlVariables.scope = resourceOwnerCredentialsGrant.scope;
+			
+			// define optional scope parameter only when scope not null
+			if(resourceOwnerCredentialsGrant.scope !== null)
+			{
+				urlVariables.scope = resourceOwnerCredentialsGrant.scope;
+			}
+			
 			urlRequest.data = urlVariables;
 			
 			// attach event listeners


### PR DESCRIPTION
We had problems with using the Resource Owner Credentials Grant with a oAuth2 Endpoint.

According to the draft there is an optional parameter "scope". 
Not sending the parameter was fine with our Endpoint, but sending it with the value "null" caused the API to search for a scope "null" which did not exist.

So we added a check in order to include the parameter only if necessary.
